### PR TITLE
Update new-app command in README for recent openshift version

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ If you want to deploy this dashboard on an OpenShift cluster, you can use the pr
 * create a new application from the template, and override some parameters
 
   ```
-  oc new-app -f https://raw.githubusercontent.com/vbehar/openshift-dashboard/master/openshift-template.yml -p APPLICATION_NAME=dashboard,DASHBOARD_TITLE="My OpenShift Dashboard",ROUTE_DNS=dashboard.somedomain.com
+  oc new-app -f https://raw.githubusercontent.com/vbehar/openshift-dashboard/master/openshift-template.yml -p APPLICATION_NAME=dashboard -p DASHBOARD_TITLE="My OpenShift Dashboard" -p ROUTE_DNS=dashboard.somedomain.com
   ```
 
 * if a build does not start, you can start one with


### PR DESCRIPTION
Recent Openshift versions no longer accept comma-separated lists of values for `oc new-app ... -p`. The command prints a warning and the deployment fails later.

    warning: --param no longer accepts comma-separated lists of values

Fixed in the commit with multiple `-p` arguments.